### PR TITLE
Change WebSocket to use new Java-Websocket factory methods

### DIFF
--- a/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
@@ -6,15 +6,16 @@ import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.parseqs.ParseQS;
 import com.github.nkzawa.thread.EventThread;
-import org.java_websocket.client.DefaultSSLWebSocketClientFactory;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft_17;
 import org.java_websocket.handshake.ServerHandshake;
-
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.*;
+import javax.net.ssl.SSLSocketFactory;
+
 
 public class WebSocket extends Transport {
 

--- a/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
@@ -95,11 +95,14 @@ public class WebSocket extends Transport {
                 }
             };
             if (this.sslContext != null) {
-                this.ws.setWebSocketFactory(new DefaultSSLWebSocketClientFactory(this.sslContext));
+                SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
+                this.ws.setSocket(factory.createSocket());
             }
             this.ws.connect();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
+        } catch (IOException e){
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Not sure how this should be dealt with...

Java-Websocket has recently updated to use java.net instead of java.nio. This came coupled with a change to the ssl factory settings. 

An example of this change can be seen here:

https://github.com/Davidiusdadi/Java-WebSocket/commit/9b0a4b8c182bbe3f384d8ee8ede54eb754900bf5#diff-72ceeab5f5ee7c6111aef0d69e724596L79

Meaning that when used with the most up-to-date Java-WebSocket library, engine.io-client errors out on the lines removed in this pull request. 

I simply changed the method to use the same method as in their example, as I had linked.

Issue 11 is the related issue: https://github.com/nkzawa/engine.io-client.java/issues/11