### PR TITLE
Replace Java-WebSocket to OkHttp WebSocket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,6 @@
     	<artifactId>okhttp-ws</artifactId>
     	<version>2.3.0</version>
     </dependency>
-    <dependency>
-    	<groupId>com.squareup.okhttp</groupId>
-    	<artifactId>mockwebserver</artifactId>
-    	<version>2.3.0</version>
-    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
     	<artifactId>okhttp-ws</artifactId>
     	<version>2.3.0</version>
     </dependency>
+    <dependency>
+    	<groupId>com.squareup.okhttp</groupId>
+    	<artifactId>mockwebserver</artifactId>
+    	<version>2.3.0</version>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,6 @@
       <version>20090211</version>
     </dependency>
     <dependency>
-      <groupId>org.java-websocket</groupId>
-      <artifactId>Java-WebSocket</artifactId>
-      <version>1.3.0</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
@@ -63,6 +58,11 @@
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>com.squareup.okhttp</groupId>
+    	<artifactId>okhttp-ws</artifactId>
+    	<version>2.3.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/github/nkzawa/engineio/client/Socket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Socket.java
@@ -10,6 +10,7 @@ import com.github.nkzawa.parseqs.ParseQS;
 import com.github.nkzawa.thread.EventThread;
 import org.json.JSONException;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -121,6 +122,7 @@ public class Socket extends Emitter {
     private Future pingTimeoutTimer;
     private Future pingIntervalTimer;
     private SSLContext sslContext;
+    private HostnameVerifier hostnameVerifier;
 
     private ReadyState readyState;
     private ScheduledExecutorService heartbeatScheduler;
@@ -197,6 +199,7 @@ public class Socket extends Emitter {
                 opts.transports : new String[]{Polling.NAME, WebSocket.NAME}));
         this.policyPort = opts.policyPort != 0 ? opts.policyPort : 843;
         this.rememberUpgrade = opts.rememberUpgrade;
+        this.hostnameVerifier = opts.hostnameVerifier;
     }
 
     /**
@@ -254,6 +257,7 @@ public class Socket extends Emitter {
         opts.timestampParam = this.timestampParam;
         opts.policyPort = this.policyPort;
         opts.socket = this;
+        opts.hostnameVerifier = this.hostnameVerifier;
 
         Transport transport;
         if (WebSocket.NAME.equals(name)) {

--- a/src/main/java/com/github/nkzawa/engineio/client/Socket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Socket.java
@@ -8,8 +8,6 @@ import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.parseqs.ParseQS;
 import com.github.nkzawa.thread.EventThread;
-import com.squareup.okhttp.OkHttpClient;
-
 import org.json.JSONException;
 
 import javax.net.ssl.SSLContext;
@@ -123,7 +121,6 @@ public class Socket extends Emitter {
     private Future pingTimeoutTimer;
     private Future pingIntervalTimer;
     private SSLContext sslContext;
-    private OkHttpClient okHttpClient;
 
     private ReadyState readyState;
     private ScheduledExecutorService heartbeatScheduler;
@@ -200,7 +197,6 @@ public class Socket extends Emitter {
                 opts.transports : new String[]{Polling.NAME, WebSocket.NAME}));
         this.policyPort = opts.policyPort != 0 ? opts.policyPort : 843;
         this.rememberUpgrade = opts.rememberUpgrade;
-        this.okHttpClient = opts.okHttpClient;
     }
 
     /**
@@ -258,7 +254,6 @@ public class Socket extends Emitter {
         opts.timestampParam = this.timestampParam;
         opts.policyPort = this.policyPort;
         opts.socket = this;
-        opts.okHttpClient = this.okHttpClient;
 
         Transport transport;
         if (WebSocket.NAME.equals(name)) {

--- a/src/main/java/com/github/nkzawa/engineio/client/Socket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Socket.java
@@ -8,6 +8,8 @@ import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.parseqs.ParseQS;
 import com.github.nkzawa.thread.EventThread;
+import com.squareup.okhttp.OkHttpClient;
+
 import org.json.JSONException;
 
 import javax.net.ssl.SSLContext;
@@ -121,6 +123,7 @@ public class Socket extends Emitter {
     private Future pingTimeoutTimer;
     private Future pingIntervalTimer;
     private SSLContext sslContext;
+    private OkHttpClient okHttpClient;
 
     private ReadyState readyState;
     private ScheduledExecutorService heartbeatScheduler;
@@ -197,6 +200,7 @@ public class Socket extends Emitter {
                 opts.transports : new String[]{Polling.NAME, WebSocket.NAME}));
         this.policyPort = opts.policyPort != 0 ? opts.policyPort : 843;
         this.rememberUpgrade = opts.rememberUpgrade;
+        this.okHttpClient = opts.okHttpClient;
     }
 
     /**
@@ -254,6 +258,7 @@ public class Socket extends Emitter {
         opts.timestampParam = this.timestampParam;
         opts.policyPort = this.policyPort;
         opts.socket = this;
+        opts.okHttpClient = this.okHttpClient;
 
         if (WebSocket.NAME.equals(name)) {
             return new WebSocket(opts);

--- a/src/main/java/com/github/nkzawa/engineio/client/Transport.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Transport.java
@@ -6,6 +6,7 @@ import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.thread.EventThread;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.util.Map;
 
@@ -42,6 +43,7 @@ public abstract class Transport extends Emitter {
     protected String timestampParam;
     protected SSLContext sslContext;
     protected Socket socket;
+    protected HostnameVerifier hostnameVerifier;
 
     protected ReadyState readyState;
 
@@ -55,6 +57,7 @@ public abstract class Transport extends Emitter {
         this.timestampRequests = opts.timestampRequests;
         this.sslContext = opts.sslContext;
         this.socket = opts.socket;
+        this.hostnameVerifier = opts.hostnameVerifier;
     }
 
     protected Transport onError(String msg, Exception desc) {
@@ -144,6 +147,7 @@ public abstract class Transport extends Emitter {
         public int policyPort = -1;
         public Map<String, String> query;
         public SSLContext sslContext;
+        public HostnameVerifier hostnameVerifier;
         protected Socket socket;
     }
 }

--- a/src/main/java/com/github/nkzawa/engineio/client/Transport.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Transport.java
@@ -5,6 +5,7 @@ import com.github.nkzawa.emitter.Emitter;
 import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.thread.EventThread;
+import com.squareup.okhttp.OkHttpClient;
 
 import javax.net.ssl.SSLContext;
 import java.util.Map;
@@ -42,6 +43,7 @@ public abstract class Transport extends Emitter {
     protected String timestampParam;
     protected SSLContext sslContext;
     protected Socket socket;
+    protected OkHttpClient okHttpClient;
 
     protected ReadyState readyState;
 
@@ -55,6 +57,7 @@ public abstract class Transport extends Emitter {
         this.timestampRequests = opts.timestampRequests;
         this.sslContext = opts.sslContext;
         this.socket = opts.socket;
+        this.okHttpClient = opts.okHttpClient;
     }
 
     protected Transport onError(String msg, Exception desc) {
@@ -144,6 +147,7 @@ public abstract class Transport extends Emitter {
         public int policyPort = -1;
         public Map<String, String> query;
         public SSLContext sslContext;
+        public OkHttpClient okHttpClient;
         protected Socket socket;
     }
 }

--- a/src/main/java/com/github/nkzawa/engineio/client/Transport.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/Transport.java
@@ -5,7 +5,6 @@ import com.github.nkzawa.emitter.Emitter;
 import com.github.nkzawa.engineio.parser.Packet;
 import com.github.nkzawa.engineio.parser.Parser;
 import com.github.nkzawa.thread.EventThread;
-import com.squareup.okhttp.OkHttpClient;
 
 import javax.net.ssl.SSLContext;
 import java.util.Map;
@@ -43,7 +42,6 @@ public abstract class Transport extends Emitter {
     protected String timestampParam;
     protected SSLContext sslContext;
     protected Socket socket;
-    protected OkHttpClient okHttpClient;
 
     protected ReadyState readyState;
 
@@ -57,7 +55,6 @@ public abstract class Transport extends Emitter {
         this.timestampRequests = opts.timestampRequests;
         this.sslContext = opts.sslContext;
         this.socket = opts.socket;
-        this.okHttpClient = opts.okHttpClient;
     }
 
     protected Transport onError(String msg, Exception desc) {
@@ -147,7 +144,6 @@ public abstract class Transport extends Emitter {
         public int policyPort = -1;
         public Map<String, String> query;
         public SSLContext sslContext;
-        public OkHttpClient okHttpClient;
         protected Socket socket;
     }
 }

--- a/src/main/java/com/github/nkzawa/engineio/client/transports/PollingXHR.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/PollingXHR.java
@@ -4,6 +4,7 @@ package com.github.nkzawa.engineio.client.transports;
 import com.github.nkzawa.emitter.Emitter;
 import com.github.nkzawa.thread.EventThread;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import java.io.*;
@@ -37,6 +38,7 @@ public class PollingXHR extends Polling {
         }
         opts.uri = this.uri();
         opts.sslContext = this.sslContext;
+        opts.hostnameVerifier = this.hostnameVerifier;
 
         Request req = new Request(opts);
 
@@ -148,12 +150,14 @@ public class PollingXHR extends Polling {
 
         private SSLContext sslContext;
         private HttpURLConnection xhr;
+        private HostnameVerifier hostnameVerifier;
 
         public Request(Options opts) {
             this.method = opts.method != null ? opts.method : "GET";
             this.uri = opts.uri;
             this.data = opts.data;
             this.sslContext = opts.sslContext;
+            this.hostnameVerifier = opts.hostnameVerifier;
         }
 
         public void create() {
@@ -170,8 +174,13 @@ public class PollingXHR extends Polling {
 
             xhr.setConnectTimeout(10000);
 
-            if (xhr instanceof HttpsURLConnection && this.sslContext != null) {
-                ((HttpsURLConnection)xhr).setSSLSocketFactory(this.sslContext.getSocketFactory());
+            if (xhr instanceof HttpsURLConnection) {
+                if (this.sslContext != null) {
+                    ((HttpsURLConnection)xhr).setSSLSocketFactory(this.sslContext.getSocketFactory());
+                }
+                if (this.hostnameVerifier != null) {
+                    ((HttpsURLConnection)xhr).setHostnameVerifier(this.hostnameVerifier);
+                }
             }
 
             Map<String, String> headers = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
@@ -317,6 +326,7 @@ public class PollingXHR extends Polling {
             public String method;
             public byte[] data;
             public SSLContext sslContext;
+            public HostnameVerifier hostnameVerifier;
         }
     }
 }

--- a/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
@@ -48,7 +48,7 @@ public class WebSocket extends Transport {
         this.emit(EVENT_REQUEST_HEADERS, headers);
 
         final WebSocket self = this;
-        final OkHttpClient client = this.okHttpClient != null ? this.okHttpClient : new OkHttpClient();
+        final OkHttpClient client = new OkHttpClient();
         if (this.sslContext != null) {
             SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
             client.setSslSocketFactory(factory);

--- a/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
@@ -53,6 +53,9 @@ public class WebSocket extends Transport {
             SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
             client.setSslSocketFactory(factory);
         }
+        if (this.hostnameVerifier != null) {
+            client.setHostnameVerifier(this.hostnameVerifier);
+        }
         Request.Builder builder = new Request.Builder().url(uri());
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             builder.addHeader(entry.getKey(), entry.getValue());

--- a/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
+++ b/src/main/java/com/github/nkzawa/engineio/client/transports/WebSocket.java
@@ -48,7 +48,7 @@ public class WebSocket extends Transport {
         this.emit(EVENT_REQUEST_HEADERS, headers);
 
         final WebSocket self = this;
-        final OkHttpClient client = new OkHttpClient();
+        final OkHttpClient client = this.okHttpClient != null ? this.okHttpClient : new OkHttpClient();
         if (this.sslContext != null) {
             SSLSocketFactory factory = sslContext.getSocketFactory();// (SSLSocketFactory) SSLSocketFactory.getDefault();
             client.setSslSocketFactory(factory);

--- a/src/test/java/com/github/nkzawa/engineio/client/SSLConnectionTest.java
+++ b/src/test/java/com/github/nkzawa/engineio/client/SSLConnectionTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -23,15 +24,11 @@ import static org.junit.Assert.assertThat;
 @RunWith(JUnit4.class)
 public class SSLConnectionTest extends Connection {
 
-    static {
-        // for test on localhost
-        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
-                new javax.net.ssl.HostnameVerifier(){
-                    public boolean verify(String hostname, javax.net.ssl.SSLSession sslSession) {
-                        return hostname.equals("localhost");
-                    }
-                });
-    }
+    static HostnameVerifier hostnameVerifier = new javax.net.ssl.HostnameVerifier(){
+        public boolean verify(String hostname, javax.net.ssl.SSLSession sslSession) {
+            return hostname.equals("localhost");
+        }
+    };
 
     private Socket socket;
 
@@ -74,6 +71,7 @@ public class SSLConnectionTest extends Connection {
 
         Socket.Options opts = createOptions();
         opts.sslContext = createSSLContext();
+        opts.hostnameVerifier = SSLConnectionTest.hostnameVerifier;
         socket = new Socket(opts);
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
@@ -98,6 +96,7 @@ public class SSLConnectionTest extends Connection {
 
         Socket.Options opts = createOptions();
         opts.sslContext = createSSLContext();
+        opts.hostnameVerifier = SSLConnectionTest.hostnameVerifier;
         socket = new Socket(opts);
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
@@ -127,7 +126,9 @@ public class SSLConnectionTest extends Connection {
         final BlockingQueue<Object> values = new LinkedBlockingQueue<Object>();
 
         Socket.setDefaultSSLContext(createSSLContext());
-        socket = new Socket(createOptions());
+        Socket.Options opts = createOptions();
+        opts.hostnameVerifier = SSLConnectionTest.hostnameVerifier;
+        socket = new Socket(opts);
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
             public void call(Object... args) {

--- a/src/test/java/com/github/nkzawa/engineio/client/SSLConnectionTest.java
+++ b/src/test/java/com/github/nkzawa/engineio/client/SSLConnectionTest.java
@@ -1,18 +1,21 @@
 package com.github.nkzawa.engineio.client;
 
 import com.github.nkzawa.emitter.Emitter;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.internal.SslContextBuilder;
-
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-
-import javax.net.ssl.HostnameVerifier;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -20,12 +23,15 @@ import static org.junit.Assert.assertThat;
 @RunWith(JUnit4.class)
 public class SSLConnectionTest extends Connection {
 
-    static HostnameVerifier hostnameVerifier = new javax.net.ssl.HostnameVerifier(){
-        public boolean verify(String hostname, javax.net.ssl.SSLSession sslSession) {
-            return true;
-        }
-    };
-
+    static {
+        // for test on localhost
+        javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(
+                new javax.net.ssl.HostnameVerifier(){
+                    public boolean verify(String hostname, javax.net.ssl.SSLSession sslSession) {
+                        return hostname.equals("localhost");
+                    }
+                });
+    }
 
     private Socket socket;
 
@@ -46,13 +52,28 @@ public class SSLConnectionTest extends Connection {
         return new String[] {"DEBUG=engine*", "PORT=" + PORT, "SSL=1"};
     }
 
+    SSLContext createSSLContext() throws GeneralSecurityException, IOException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        File file = new File("src/test/resources/keystore.jks");
+        ks.load(new FileInputStream(file), "password".toCharArray());
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, "password".toCharArray());
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ks);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return sslContext;
+    }
+
     @Test(timeout = TIMEOUT)
     public void connect() throws Exception {
         final BlockingQueue<Object> values = new LinkedBlockingQueue<Object>();
 
         Socket.Options opts = createOptions();
-        opts.sslContext = SslContextBuilder.localhost();
-        opts.okHttpClient = new OkHttpClient().setHostnameVerifier(hostnameVerifier);
+        opts.sslContext = createSSLContext();
         socket = new Socket(opts);
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
@@ -76,8 +97,7 @@ public class SSLConnectionTest extends Connection {
         final BlockingQueue<Object> values = new LinkedBlockingQueue<Object>();
 
         Socket.Options opts = createOptions();
-        opts.sslContext = SslContextBuilder.localhost();
-        opts.okHttpClient = new OkHttpClient().setHostnameVerifier(hostnameVerifier);
+        opts.sslContext = createSSLContext();
         socket = new Socket(opts);
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
@@ -106,10 +126,8 @@ public class SSLConnectionTest extends Connection {
     public void defaultSSLContext() throws Exception {
         final BlockingQueue<Object> values = new LinkedBlockingQueue<Object>();
 
-        Socket.Options opts = createOptions();
-        Socket.setDefaultSSLContext(SslContextBuilder.localhost());
-        opts.okHttpClient = new OkHttpClient().setHostnameVerifier(hostnameVerifier);
-        socket = new Socket(opts);
+        Socket.setDefaultSSLContext(createSSLContext());
+        socket = new Socket(createOptions());
         socket.on(Socket.EVENT_OPEN, new Emitter.Listener() {
             @Override
             public void call(Object... args) {


### PR DESCRIPTION
Cause Java-WebSocket lib on Maven update too slow, and OkHttp will fully support websocket in the future, we should replace it.