### PR TITLE
Fix http headers type

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,17 @@ socket.on(Socket.EVENT_TRANSPORT, new Emitter.listener() {
       @Override
       public void call(Object... args) {
         @SuppressWarnings("unchecked")
-        Map<String, String> headers = (Map<String, String>)args[0];
-        // send cookies to server.
-        headers.put("Cookie", "foo=1;");
+        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+        // send cookie value to server.
+        headers.put("Cookie", Arrays.asList("foo=1;"));
       }
     }).on(Transport.EVENT_RESPONSE_HEADERS, new Emitter.Listener() {
       @Override
       public void call(Object... args) {
         @SuppressWarnings("unchecked")
-        Map<String, String> headers = (Map<String, String>)args[0];
-        // get cookies from server.
-        String cookie = headers.get("Set-Cookie");
+        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+        // receive cookie value from server.
+        String cookie = headers.get("Set-Cookie").get(0);
       }
     });
   }

--- a/src/test/java/com/github/nkzawa/engineio/client/ServerConnectionTest.java
+++ b/src/test/java/com/github/nkzawa/engineio/client/ServerConnectionTest.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -61,7 +63,7 @@ public class ServerConnectionTest extends Connection {
         }).on(Socket.EVENT_MESSAGE, new Emitter.Listener() {
             @Override
             public void call(Object... args) {
-                events.offer((String)args[0]);
+                events.offer((String) args[0]);
             }
         });
         socket.open();
@@ -89,7 +91,7 @@ public class ServerConnectionTest extends Connection {
         HandshakeData data = (HandshakeData)args[0];
         assertThat(data.sid, is(notNullValue()));
         assertThat(data.upgrades, is(not(emptyArray())));
-        assertThat(data.pingTimeout, is(greaterThan((long)0)));
+        assertThat(data.pingTimeout, is(greaterThan((long) 0)));
         assertThat(data.pingInterval, is(greaterThan((long) 0)));
         socket.close();
     }
@@ -144,15 +146,17 @@ public class ServerConnectionTest extends Connection {
                     @Override
                     public void call(Object... args) {
                         @SuppressWarnings("unchecked")
-                        Map<String, String> headers = (Map<String, String>)args[0];
-                        headers.put("X-EngineIO", "foo");
+                        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+                        headers.put("X-EngineIO", Arrays.asList("foo"));
                     }
                 }).on(Transport.EVENT_RESPONSE_HEADERS, new Emitter.Listener() {
                     @Override
                     public void call(Object... args) {
                         @SuppressWarnings("unchecked")
-                        Map<String, String> headers = (Map<String, String>)args[0];
-                        messages.offer(headers.get("X-EngineIO"));
+                        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+                        List<String> values = headers.get("X-EngineIO");
+                        messages.offer(values.get(0));
+                        messages.offer(values.get(1));
                     }
                 });
             }
@@ -160,7 +164,7 @@ public class ServerConnectionTest extends Connection {
         socket.open();
 
         assertThat(messages.take(), is("foo"));
-        assertThat(messages.take(), is("foo"));
+        assertThat(messages.take(), is("hi"));
         socket.close();
     }
 
@@ -180,21 +184,24 @@ public class ServerConnectionTest extends Connection {
                     @Override
                     public void call(Object... args) {
                         @SuppressWarnings("unchecked")
-                        Map<String, String> headers = (Map<String, String>)args[0];
-                        headers.put("X-EngineIO", "foo");
+                        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+                        headers.put("X-EngineIO", Arrays.asList("foo"));
                     }
                 }).on(Transport.EVENT_RESPONSE_HEADERS, new Emitter.Listener() {
                     @Override
                     public void call(Object... args) {
                         @SuppressWarnings("unchecked")
-                        Map<String, String> headers = (Map<String, String>)args[0];
-                        messages.offer(headers.get("X-EngineIO"));
+                        Map<String, List<String>> headers = (Map<String, List<String>>)args[0];
+                        List<String> values = headers.get("X-EngineIO");
+                        messages.offer(values.get(0));
+                        messages.offer(values.get(1));
                     }
                 });
             }
         });
         socket.open();
 
+        assertThat(messages.take(), is("hi"));
         assertThat(messages.take(), is("foo"));
         socket.close();
     }
@@ -265,7 +272,7 @@ public class ServerConnectionTest extends Connection {
             }
         });
 
-        assertThat((String)values.take(), is(Polling.NAME));
+        assertThat((String) values.take(), is(Polling.NAME));
         assertThat((String)values.take(), is(not(WebSocket.NAME)));
     }
 }

--- a/src/test/resources/server.js
+++ b/src/test/resources/server.js
@@ -45,7 +45,7 @@ before(server, 'handleRequest', function(req, res) {
   // echo a header value
   var value = req.headers['x-engineio'];
   if (!value) return;
-  res.setHeader('X-EngineIO', value);
+  res.setHeader('X-EngineIO', ['hi', value]);
 });
 
 before(server, 'handleUpgrade', function(req, socket, head) {
@@ -53,6 +53,7 @@ before(server, 'handleUpgrade', function(req, socket, head) {
   var value = req.headers['x-engineio'];
   if (!value) return;
   this.ws.once('headers', function(headers) {
+    headers.push('X-EngineIO: hi');
     headers.push('X-EngineIO: ' + value);
   });
 });


### PR DESCRIPTION
`Set-Cookie` header and custom headers can have multiple values, therefore `Transport.EVENT_RESPONSE_HEADERS` event and `Transport.EVENT_RESPONSE_HEADERS` event should take the type `Map<String, List<String>>` instead of `Map<String, String>`.
This is a backward incompatible change.

Related: https://github.com/nkzawa/socket.io-client.java/issues/185